### PR TITLE
Fix: Use TZ environment variable for Django

### DIFF
--- a/rustdesk_server_api/settings.py
+++ b/rustdesk_server_api/settings.py
@@ -150,7 +150,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en'
 
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = os.getenv('TZ', 'UTC')
 
 USE_I18N = True
 


### PR DESCRIPTION
As of now, `TIME_ZONE` variable is hardcoded with value 'America/Chicago'.
The more correct option is to use `TZ` environment variable that is also specified in the README and as the default value (if `TZ` is not set) - `UTC`.